### PR TITLE
problem in node name 

### DIFF
--- a/locale/colored_concrete.zh_CN.tr
+++ b/locale/colored_concrete.zh_CN.tr
@@ -1,0 +1,17 @@
+# textdomain: colored_concrete
+White Concrete=白色混凝土
+Orange Concrete=橙色混凝土
+Magenta Concrete=洋红色混凝土
+Lightblue Concrete=亮蓝色混凝土
+Yellow Concrete=黄色混凝土
+Lightgreen Concrete=亮绿色混凝土
+Pink Concrete=粉色混凝土
+Darkgrey Concrete=暗灰色混凝土
+Grey Concrete=灰色混凝土
+Turquoise Concrete=青绿色混凝土
+Violet Concrete=紫色混凝土
+Blue Concrete=蓝色混凝土
+Brown Concrete=褐色混凝土
+Green Concrete=绿色混凝土
+Red Concrete=红色混凝土
+Black Concrete=黑色混凝土

--- a/register.lua
+++ b/register.lua
@@ -23,10 +23,10 @@ local concrete = {
 for _, concrete in pairs(concrete) do
 
     minetest.register_node("colored_concrete:" .. concrete[1], {
-	    description = S(concrete[2] .. " Concrete"),
-	    tiles = {"colored_concrete_" .. concrete[1] .. ".png"},
-	    groups = {cracky = 3},
-	    sounds = default.node_sound_stone_defaults()
+      description = S(concrete[2] .. " Concrete"),
+      tiles = {"colored_concrete_" .. concrete[1] .. ".png"},
+      groups = {cracky = 3},
+      sounds = default.node_sound_stone_defaults()
     })
 
     local dye_string = "dye:" .. concrete[1]
@@ -44,12 +44,15 @@ for _, concrete in pairs(concrete) do
     end
 
     if moreblocks then
-        stairsplus:register_all("moreblocks", "colored_concrete:" .. concrete[1], "colored_concrete:" .. concrete[1], {
+        stairsplus:register_all("moreblocks", "colored_concrete_" .. concrete[1], "colored_concrete:" .. concrete[1], {
             description = S(concrete[2] .. " Concrete"),
             tiles = {"colored_concrete_" .. concrete[1] .. ".png"},
             groups = {cracky = 3},
             sounds = default.node_sound_stone_defaults(),
         })
+        if minetest.settings:get_bool("colored_concrete_enable_aliases", "true") then
+            stairsplus:register_alias_all("moreblocks", "colored_concrete:" .. concrete[1], "moreblocks", "colored_concrete_" .. concrete[1])
+        end
     end
 end
 

--- a/register.lua
+++ b/register.lua
@@ -23,10 +23,10 @@ local concrete = {
 for _, concrete in pairs(concrete) do
 
     minetest.register_node("colored_concrete:" .. concrete[1], {
-      description = S(concrete[2] .. " Concrete"),
-      tiles = {"colored_concrete_" .. concrete[1] .. ".png"},
-      groups = {cracky = 3},
-      sounds = default.node_sound_stone_defaults()
+        description = S(concrete[2] .. " Concrete"),
+        tiles = {"colored_concrete_" .. concrete[1] .. ".png"},
+        groups = {cracky = 3},
+        sounds = default.node_sound_stone_defaults()
     })
 
     local dye_string = "dye:" .. concrete[1]

--- a/register.lua
+++ b/register.lua
@@ -23,10 +23,10 @@ local concrete = {
 for _, concrete in pairs(concrete) do
 
     minetest.register_node("colored_concrete:" .. concrete[1], {
-        description = S(concrete[2] .. " Concrete"),
-        tiles = {"colored_concrete_" .. concrete[1] .. ".png"},
-        groups = {cracky = 3},
-        sounds = default.node_sound_stone_defaults()
+	    description = S(concrete[2] .. " Concrete"),
+	    tiles = {"colored_concrete_" .. concrete[1] .. ".png"},
+	    groups = {cracky = 3},
+	    sounds = default.node_sound_stone_defaults()
     })
 
     local dye_string = "dye:" .. concrete[1]


### PR DESCRIPTION
When using colored_concrete with moreblocks, there will be two `:` in one name, which will cause problems when used with some mods (such as comboblock). I changed it to `_`. Aliases are also set for backward compatibility.
[Naming conventions](https://minetest.gitlab.io/minetest/mods/#naming-conventions)

Also added Simplified Chinese translation.